### PR TITLE
Fixed genres, wrong name

### DIFF
--- a/frontend/src/components/pages/gamepage/GameTable.js
+++ b/frontend/src/components/pages/gamepage/GameTable.js
@@ -1,9 +1,8 @@
 
 //Eget komponent for info om spill som brukes i GamePage
 export default function GameTable({game}){
-
-
-const publishers = game?.publishers?.map((pub, index)=>{
+ 
+  const publishers = game?.publishers?.map((pub, index)=>{
     return (
       <td key={index}>
         {pub.name}
@@ -14,7 +13,7 @@ const publishers = game?.publishers?.map((pub, index)=>{
   const genres = game?.genres?.map((genre, index)=>{
     return (
       <td key={index}>
-        {genre.title}
+        {genre.name}
       </td>
     )
   })
@@ -37,6 +36,7 @@ const publishers = game?.publishers?.map((pub, index)=>{
       <td key={index}>{store.store.name}</td>
     )
   })
+
     return (
         <table className="game-info">
           <tbody>


### PR DESCRIPTION
Sjangere hadde .title i stedet for .name. Nå vises sjangere i GamePage