### PR TITLE
Playtime disabled in GameShop & GameShopPage

### DIFF
--- a/frontend/src/components/dashboardComponents/GameShop.js
+++ b/frontend/src/components/dashboardComponents/GameShop.js
@@ -23,7 +23,7 @@ export default function GameShop() {
             image={game.background_image}
             slug={game.slug}
             title={game.name}
-            playTime={game.playtime}
+            playTime={0}
             genre={game.genres.map((genre, index) => (
               <li key={index}>{genre.name}</li>
             ))}

--- a/frontend/src/components/pages/GameShopPage.js
+++ b/frontend/src/components/pages/GameShopPage.js
@@ -36,6 +36,7 @@ export default function GameShopPage() {
               <GameCard
                 key={index}
                 title={game?.name}
+                playTime={0}
                 genre={game?.genres.map((genre, i) => (
                   <li key={i}>{genre?.name}</li>
                 ))}


### PR DESCRIPTION
Nå er playtime 0 på både GamePage og GameShopPage (dvs ingen playtime seksjon vil vises uansett om objektet har playtime eller ei). Så blir det forutsigbart og gjennomført